### PR TITLE
replace SqlEditorLeftBar2 with SqlEditorLeftBar

### DIFF
--- a/superset-frontend/src/SqlLab/components/SqlEditor.jsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor.jsx
@@ -699,17 +699,17 @@ class SqlEditor extends React.PureComponent {
           timeout={300}
         >
           <div className="schemaPane">
-            {/* <SqlEditorLeftBar
+            <SqlEditorLeftBar
               database={this.props.database}
               queryEditor={this.props.queryEditor}
               tables={this.props.tables}
               actions={this.props.actions}
-            /> */}
-            <SqlEditorLeftBar2
+            />
+            {/* <SqlEditorLeftBar2
               databases={this.props.databases}
               queryEditor={this.props.queryEditor}
               actions={this.props.actions}
-            />
+            /> */}
           </div>
         </CSSTransition>
         {this.queryPane()}


### PR DESCRIPTION
### SUMMARY
Go back to superset default sql editor. SqlEditorLeftBar2 has issues with setting the right database for current query execution.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
